### PR TITLE
unique ptr requires a delete definition

### DIFF
--- a/Source/LlamaCore/Private/LlamaComponent.cpp
+++ b/Source/LlamaCore/Private/LlamaComponent.cpp
@@ -768,8 +768,10 @@ namespace Internal
 } // namespace Internal
 
 ULlamaComponent::ULlamaComponent(const FObjectInitializer &ObjectInitializer)
-    : UActorComponent(ObjectInitializer), llama(make_unique<Internal::FLlama>())
+    : UActorComponent(ObjectInitializer)
 {
+    llama = new Internal::FLlama();
+
     PrimaryComponentTick.bCanEverTick = true;
     PrimaryComponentTick.bStartWithTickEnabled = true;
 
@@ -876,7 +878,14 @@ ULlamaComponent::ULlamaComponent(const FObjectInitializer &ObjectInitializer)
     ModelParams.Advanced.PartialsSeparators.Add(TEXT("!"));
 }
 
-ULlamaComponent::~ULlamaComponent() = default;
+ULlamaComponent::~ULlamaComponent()
+{
+	if (llama)
+	{
+		delete llama;
+		llama = nullptr;
+	}
+}
 
 void ULlamaComponent::Activate(bool bReset)
 {

--- a/Source/LlamaCore/Public/LlamaComponent.h
+++ b/Source/LlamaCore/Public/LlamaComponent.h
@@ -3,7 +3,6 @@
 #pragma once
 #include <Components/ActorComponent.h>
 #include <CoreMinimal.h>
-#include <memory>
 
 #include "LlamaComponent.generated.h"
 
@@ -342,7 +341,7 @@ public:
     TArray<FString> DebugListDirectoryContent(const FString& InPath);
 
 private:
-    std::unique_ptr<Internal::FLlama> llama;
+    class Internal::FLlama* llama;
 
     TFunction<void(FString, int32)> TokenCallbackInternal;
 };


### PR DESCRIPTION
std unique_ptr and TUniquePtr both require a defined destructor to compile.  A forward declaration is not sufficient for proper compilation.  I suspect this is hidden by Unreal's Unity build system.

The following is one pattern to fix the issue.