### PR TITLE
Update Plugin Config

### DIFF
--- a/Llama.uplugin
+++ b/Llama.uplugin
@@ -11,7 +11,7 @@
 	"DocsURL": "https://github.com/getnamo/Llama-Unreal",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"CanContainContent": true,
+	"CanContainContent": false,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,
 	"Installed": false,


### PR DESCRIPTION
`Can Contain Content` should only be true when the plugin has content assets. When true UE mounts a content folder in the Plugins folder. This plugin has no content, so this should be false to not clutter the Plugin content folders.